### PR TITLE
Add custom ClientFinder

### DIFF
--- a/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendClientFinder.java
+++ b/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendClientFinder.java
@@ -1,0 +1,131 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.server.pac4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.client.finder.DefaultSecurityClientFinder;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.util.CommonHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+
+public class LegendClientFinder extends DefaultSecurityClientFinder
+{
+  private static final Logger logger = LoggerFactory.getLogger(DefaultSecurityClientFinder.class);
+
+  String clientNameParameter = new DefaultSecurityClientFinder().getClientNameParameter();
+  String defaultClient;
+
+  public LegendClientFinder(String defaultClient)
+  {
+    super();
+    this.defaultClient = defaultClient;
+  }
+
+  public LegendClientFinder()
+  {
+    super();
+  }
+
+  @Override
+  public List<Client> find(Clients clients, WebContext context, String clientNames)
+  {
+    List<Client> result = new ArrayList();
+    String securityClientNames = clientNames;
+    logger.debug("Provided clientNames: {}", clientNames);
+    if (clientNames == null)
+    {
+      securityClientNames = clients.getDefaultSecurityClients();
+      logger.debug("Default security clients: {}", securityClientNames);
+      if (securityClientNames == null && clients.findAllClients().size() == 1)
+      {
+        securityClientNames = ((Client) clients.getClients().get(0)).getName();
+        logger.debug("Only client: {}", securityClientNames);
+      }
+    }
+
+    if (CommonHelper.isNotBlank(securityClientNames))
+    {
+      List<String> names = Arrays.asList(securityClientNames.split(","));
+      String clientNameOnRequest = context.getRequestParameter(this.clientNameParameter);
+      logger.debug("clientNameOnRequest: {}", clientNameOnRequest);
+      String nameFound;
+      if (clientNameOnRequest != null)
+      {
+        result = findUtil(clients, names, clientNameOnRequest);
+      } else if (defaultClient != null)
+      {
+        logger.debug("defaultClient: {}", defaultClient);
+        result = findUtil(clients, names, defaultClient);
+      } else
+      {
+        Iterator var13 = names.iterator();
+
+        while (var13.hasNext())
+        {
+          nameFound = (String) var13.next();
+          Client client = clients.findClient(nameFound);
+          result.add(client);
+        }
+      }
+    }
+
+    logger.debug("result: {}", result.stream().map((c) ->
+    {
+      return c.getName();
+    }).collect(Collectors.toList()));
+    return result;
+  }
+
+  public List<Client> findUtil(Clients clients, List<String> names, String toFind)
+  {
+    List<Client> result = new ArrayList();
+    Client client = clients.findClient(toFind);
+    String nameFound = client.getName();
+    boolean found = false;
+    Iterator var11 = names.iterator();
+
+    while (var11.hasNext())
+    {
+      String name = (String) var11.next();
+      if (CommonHelper.areEqualsIgnoreCaseAndTrim(name, nameFound))
+      {
+        result.add(client);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found)
+    {
+      throw new TechnicalException("Client not allowed: " + nameFound);
+    }
+    return result;
+  }
+
+  public String getDefaultClient()
+  {
+    return defaultClient;
+  }
+}

--- a/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jConfiguration.java
+++ b/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jConfiguration.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.List;
 import org.pac4j.core.authorization.authorizer.Authorizer;
 import org.pac4j.core.client.Client;
+import org.pac4j.core.client.finder.ClientFinder;
+import org.pac4j.core.client.finder.DefaultSecurityClientFinder;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public final class LegendPac4jConfiguration
@@ -31,6 +33,7 @@ public final class LegendPac4jConfiguration
   private String defaults;
   private List<Authorizer> authorizers = ImmutableList.of();
   private List<Client> clients;
+  private String defaultClient;
   private String mongoUri;
   private String mongoDb;
   private MongoSessionConfiguration mongoSession = new MongoSessionConfiguration();
@@ -89,6 +92,19 @@ public final class LegendPac4jConfiguration
     this.clients = clients;
   }
 
+  public ClientFinder getDefaultSecurityClient()
+  {
+    ClientFinder f;
+    if (this.defaultClient != null)
+    {
+      f = new LegendClientFinder(this.defaultClient);
+    } else
+    {
+      f = new LegendClientFinder();
+    }
+    return f;
+  }
+
   private void defaultClients(List<Client> clients)
   {
     if (this.clients == null || this.clients.isEmpty())
@@ -133,6 +149,11 @@ public final class LegendPac4jConfiguration
   public String getMongoUri()
   {
     return mongoUri;
+  }
+
+  public void setDefaultClient(String defaultClient)
+  {
+    this.defaultClient = defaultClient;
   }
 
   public void setMongoUri(String mongoUri)

--- a/legend-shared-pac4j/src/test/java/org/finos/legend/server/pac4j/LegendPac4JBundleTest.java
+++ b/legend-shared-pac4j/src/test/java/org/finos/legend/server/pac4j/LegendPac4JBundleTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import org.junit.Test;
 import org.pac4j.core.config.Config;
+import org.pac4j.core.engine.DefaultSecurityLogic;
 import org.pac4j.dropwizard.Pac4jFactory;
 
 public class LegendPac4JBundleTest
@@ -37,4 +38,21 @@ public class LegendPac4JBundleTest
     Config builtConfig = factory.build();
     assertEquals(config.getClients(), builtConfig.getClients().getClients());
   }
+
+  @Test
+  public void testPac4jFactoryWithMultipleClients()
+  {
+    LegendPac4jConfiguration config = new LegendPac4jConfiguration();
+    config.setCallbackPrefix("/test");
+    config.setClients(ImmutableList.of(new TestClient(), new SecondTestClient()));
+    config.setDefaultClient("SecondTestClient");
+    LegendPac4jBundle<Configuration> bundle = new LegendPac4jBundle<>(c -> config);
+    Pac4jFactory factory = bundle.getPac4jFactory(new Configuration());
+    assertEquals("/test/callback", factory.getCallbackUrl());
+    assertEquals(config.getClients(), factory.getClients());
+    Config builtConfig = factory.build();
+    assertEquals("SecondTestClient", ((LegendClientFinder)((DefaultSecurityLogic)builtConfig.getSecurityLogic()).getClientFinder()).getDefaultClient());
+    assertEquals(config.getClients(), builtConfig.getClients().getClients());
+  }
+
 }

--- a/legend-shared-pac4j/src/test/java/org/finos/legend/server/pac4j/SecondTestClient.java
+++ b/legend-shared-pac4j/src/test/java/org/finos/legend/server/pac4j/SecondTestClient.java
@@ -1,0 +1,15 @@
+package org.finos.legend.server.pac4j;
+
+import org.pac4j.core.client.DirectClient;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.CommonProfile;
+
+public class SecondTestClient extends DirectClient<Credentials, CommonProfile> {
+
+  @Override
+  protected void clientInit()
+  {
+
+  }
+
+}


### PR DESCRIPTION
Add a client finder that allows us to specify a default client in instances where there are multiple clients available and the request does not specify which to use.