### PR TITLE
chore: fix whitesource issues and update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pierredebelen @gs-bracej @Yasirmod17 @aormerod-gs @MauricioUyaguari
+* @pierredebelen @aormerod-gs @gs-bracej @akphi @Yasirmod17 @MauricioUyaguari @epsstan

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Dependencies -->
         <commons.lang.version>2.6</commons.lang.version>
-        <dropwizard.version>1.3.28</dropwizard.version>
+        <dropwizard.version>1.3.29</dropwizard.version>
         <dropwizard.pac4j.version>3.0.0</dropwizard.pac4j.version>
         <guava.version>30.0-jre</guava.version>
         <jackson.annotations.version>2.10.1</jackson.annotations.version>
@@ -56,14 +56,14 @@
         <jaxb.runtime.version>2.3.2</jaxb.runtime.version>
         <jersey.client.version>2.23.2</jersey.client.version>
         <jersey.test.framework.version>2.23.1</jersey.test.framework.version>
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.37.v20210219</jetty.version>
         <joda.time.version>2.10.1</joda.time.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <mimeparse.version>0.1.3.3</mimeparse.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <mockito.version>3.5.10</mockito.version>
-        <mongo.driver.version>3.10.2</mongo.driver.version>
+        <mongo.driver.version>3.12.8</mongo.driver.version>
         <mongo.server.version>1.21.0</mongo.server.version>
         <nimbus.jwt.version>8.0</nimbus.jwt.version>
         <opentracing.jaxrs2.version>0.5.0</opentracing.jaxrs2.version>
@@ -639,6 +639,11 @@
                         <artifactId>commons-lang</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Bump version for `jetty` and `mongo-java-driver` to address Whitesource alerts