### PR TITLE
Log exception on trace spans when fail to read/write http request/response

### DIFF
--- a/checkstyle_legend.xml
+++ b/checkstyle_legend.xml
@@ -42,15 +42,6 @@
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
     </module>
-    <module name="RegexpMultiline">
-        <property name="minimum" value="1" />
-        <property name="maximum" value="2" />
-        <property name="message" value="File does not contain a valid Copyright header."/>
-        <property
-                name="format"
-                value=".* Copyright .*|\n.*www.apache.org/licenses/LICENSE-2.0"/>
-    </module>
-
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/legend-shared-opentracing-servlet-filter/pom.xml
+++ b/legend-shared-opentracing-servlet-filter/pom.xml
@@ -64,5 +64,23 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/InterceptorSpanDecorator.java
+++ b/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/InterceptorSpanDecorator.java
@@ -1,0 +1,58 @@
+// Forked from:
+//      https://github.com/opentracing-contrib/java-jaxrs/blob/master/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/serialization/InterceptorSpanDecorator.java
+//
+// This includes enhancements requested on issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/issues/147
+//
+// PR with contribution for solving issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/pull/148
+//
+// Once issue is solved, we should update artifact version and delete this fork
+
+package org.finos.legend.opentracing.jaxrs2;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+
+import javax.ws.rs.ext.InterceptorContext;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+public interface InterceptorSpanDecorator
+{
+    void decorateRead(InterceptorContext context, Span span);
+
+    void decorateWrite(InterceptorContext context, Span span);
+
+    void decorateReadException(Exception e, ReaderInterceptorContext context, Span span);
+
+    void decorateWriteException(Exception e, WriterInterceptorContext context, Span span);
+
+    InterceptorSpanDecorator STANDARD_TAGS = new InterceptorSpanDecorator()
+    {
+        @Override
+        public void decorateRead(InterceptorContext context, Span span)
+        {
+            span.setTag("media.type", context.getMediaType().toString());
+            span.setTag("entity.type", context.getType().getName());
+        }
+
+        @Override
+        public void decorateWrite(InterceptorContext context, Span span)
+        {
+            decorateRead(context, span);
+        }
+
+        @Override
+        public void decorateReadException(Exception e, ReaderInterceptorContext context, Span span)
+        {
+            Tags.ERROR.set(span, true);
+        }
+
+        @Override
+        public void decorateWriteException(Exception e, WriterInterceptorContext context, Span span)
+        {
+            Tags.ERROR.set(span, true);
+        }
+    };
+}

--- a/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/ServerTracingInterceptor.java
+++ b/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/ServerTracingInterceptor.java
@@ -1,0 +1,50 @@
+// Forked from
+//      https://github.com/opentracing-contrib/java-jaxrs/blob/master/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingInterceptor.java
+//
+// This includes enhancements requested on issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/issues/147
+//
+// PR with contribution for solving issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/pull/148
+//
+// Once issue is solved, we should update artifact version and delete this fork
+
+package org.finos.legend.opentracing.jaxrs2;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jaxrs2.internal.CastUtils;
+import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.InterceptorContext;
+import java.util.List;
+
+import static io.opentracing.contrib.jaxrs2.internal.SpanWrapper.PROPERTY_NAME;
+
+public class ServerTracingInterceptor extends TracingInterceptor
+{
+    /**
+     * Apache CFX does not seem to publish the PROPERTY_NAME into the Interceptor context.
+     * Use the current HttpServletRequest to lookup the current span wrapper.
+     */
+    @Context
+    private HttpServletRequest servletReq;
+
+    public ServerTracingInterceptor(Tracer tracer, List<InterceptorSpanDecorator> spanDecorators)
+    {
+        super(tracer, spanDecorators);
+    }
+
+    @Override
+    protected SpanWrapper findSpan(InterceptorContext context)
+    {
+        SpanWrapper spanWrapper = CastUtils.cast(context.getProperty(PROPERTY_NAME), SpanWrapper.class);
+        if (spanWrapper == null && servletReq != null)
+        {
+            spanWrapper = CastUtils
+                    .cast(servletReq.getAttribute(PROPERTY_NAME), SpanWrapper.class);
+        }
+        return spanWrapper;
+    }
+}

--- a/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/TracingInterceptor.java
+++ b/legend-shared-opentracing-servlet-filter/src/main/java/org/finos/legend/opentracing/jaxrs2/TracingInterceptor.java
@@ -1,0 +1,142 @@
+// Forked from
+//      https://github.com/opentracing-contrib/java-jaxrs/blob/master/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/serialization/TracingInterceptor.java
+//
+// This includes enhancements requested on issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/issues/147
+//
+// PR with contribution for solving issue:
+//      https://github.com/opentracing-contrib/java-jaxrs/pull/148
+//
+// Once issue is solved, we should update artifact version and delete this fork
+
+package org.finos.legend.opentracing.jaxrs2;
+
+import io.opentracing.References;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
+import io.opentracing.noop.NoopSpan;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.InterceptorContext;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+public abstract class TracingInterceptor implements WriterInterceptor, ReaderInterceptor
+{
+    private final Tracer tracer;
+    private final Collection<InterceptorSpanDecorator> spanDecorators;
+
+    public TracingInterceptor(Tracer tracer,
+                              List<InterceptorSpanDecorator> spanDecorators)
+    {
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(spanDecorators);
+        this.tracer = tracer;
+        this.spanDecorators = new ArrayList<>(spanDecorators);
+    }
+
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext context)
+            throws IOException, WebApplicationException
+    {
+        Span span = buildSpan(context, "deserialize");
+        try (Scope scope = tracer.activateSpan(span))
+        {
+            decorateRead(context, span);
+            try
+            {
+                return context.proceed();
+            } catch (Exception e)
+            {
+                decorateReadException(e, context, span);
+                throw e;
+            }
+        } finally
+        {
+            span.finish();
+        }
+    }
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context)
+            throws IOException, WebApplicationException
+    {
+        Span span = buildSpan(context, "serialize");
+        try (Scope scope = tracer.activateSpan(span))
+        {
+            decorateWrite(context, span);
+            try
+            {
+                context.proceed();
+            } catch (Exception e)
+            {
+                decorateWriteException(e, context, span);
+                throw e;
+            }
+        } finally
+        {
+            span.finish();
+        }
+    }
+
+    private Span buildSpan(InterceptorContext context, String operationName)
+    {
+        final SpanWrapper spanWrapper = findSpan(context);
+        if (spanWrapper == null)
+        {
+            return NoopSpan.INSTANCE;
+        }
+        final Tracer.SpanBuilder spanBuilder = tracer.buildSpan(operationName);
+        if (spanWrapper.isFinished())
+        {
+            spanBuilder.addReference(References.FOLLOWS_FROM, spanWrapper.get().context());
+        } else
+        {
+            spanBuilder.asChildOf(spanWrapper.get());
+        }
+        return spanBuilder.start();
+    }
+
+    protected abstract SpanWrapper findSpan(InterceptorContext context);
+
+    private void decorateRead(InterceptorContext context, Span span)
+    {
+        for (InterceptorSpanDecorator decorator : spanDecorators)
+        {
+            decorator.decorateRead(context, span);
+        }
+    }
+
+    private void decorateWrite(InterceptorContext context, Span span)
+    {
+        for (InterceptorSpanDecorator decorator : spanDecorators)
+        {
+            decorator.decorateWrite(context, span);
+        }
+    }
+
+    private void decorateReadException(Exception e, ReaderInterceptorContext context, Span span)
+    {
+        for (InterceptorSpanDecorator decorator : spanDecorators)
+        {
+            decorator.decorateReadException(e, context, span);
+        }
+    }
+
+    private void decorateWriteException(Exception e, WriterInterceptorContext context, Span span)
+    {
+        for (InterceptorSpanDecorator decorator : spanDecorators)
+        {
+            decorator.decorateWriteException(e, context, span);
+        }
+    }
+}

--- a/legend-shared-server/pom.xml
+++ b/legend-shared-server/pom.xml
@@ -150,6 +150,11 @@
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 

--- a/legend-shared-server/src/test/java/org/finos/legend/server/shared/bundles/OpenTracingBundleTest.java
+++ b/legend-shared-server/src/test/java/org/finos/legend/server/shared/bundles/OpenTracingBundleTest.java
@@ -1,0 +1,330 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.server.shared.bundles;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.opentracing.log.Fields;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class OpenTracingBundleTest
+{
+  private static final CyclicBarrier REQ_BARR = new CyclicBarrier(2);
+
+  private static final MockTracer MOCK_TRACER = new MockTracer()
+  {
+    @Override
+    protected void onSpanFinished(MockSpan mockSpan)
+    {
+      // sync with caller when is root span
+      // from client perspective, jersey will complete request while internally still executing some post-request filters and interceptors
+      // and these need to complete for the span to be finished
+      if (mockSpan.tags().get("serverHost") != null)
+      {
+        try
+        {
+          REQ_BARR.await(2, TimeUnit.SECONDS);
+        }
+        catch (Exception e)
+        {
+          e.printStackTrace();
+        }
+      }
+    }
+  };
+
+  @ClassRule
+  public static final DropwizardAppRule<TestConfig> RULE =
+      new DropwizardAppRule<>(TestApp.class, ResourceHelpers.resourceFilePath("testConfig.json"));
+
+  @After
+  public void tearDown()
+  {
+    REQ_BARR.reset();
+    MOCK_TRACER.reset();
+  }
+
+  @Test
+  public void testNoTracesOnSkippedPath() throws Exception
+  {
+    String methodPath = "skipped";
+    try(Response response = execPostCall(methodPath, 200))
+    {
+      assertEquals(response.readEntity(String.class), "Hello World!");
+
+      Assert.assertNull(response.getHeaderString("traceid"));
+      Assert.assertNull(response.getHeaderString("spanid"));
+
+      List<MockSpan> finishedSpans = MOCK_TRACER.finishedSpans();
+      Assert.assertEquals(0, finishedSpans.size());
+    }
+  }
+
+  @Test
+  public void testTracesOnHappyPath() throws Exception
+  {
+    String methodPath = "happyPath";
+    try(Response response = execPostCall(methodPath, 200))
+    {
+      assertEquals(response.readEntity(String.class), "Hello World!");
+
+      Assert.assertNotNull(response.getHeaderString("traceid"));
+      Assert.assertNotNull(response.getHeaderString("spanid"));
+
+      // is a list of spans in the order they were close/finish
+      // deserialization, serialization, and root
+      List<MockSpan> finishedSpans = MOCK_TRACER.finishedSpans();
+      Assert.assertEquals(3, finishedSpans.size());
+
+      MockSpan deserializationSpan = finishedSpans.get(0);
+      Assert.assertEquals("deserialize", deserializationSpan.operationName());
+      Assert.assertEquals(2, deserializationSpan.tags().size());
+      Assert.assertNotNull(deserializationSpan.tags().get("entity.type"));
+      Assert.assertEquals(MediaType.TEXT_PLAIN, deserializationSpan.tags().get("media.type"));
+      Assert.assertEquals(0, deserializationSpan.logEntries().size());
+
+      MockSpan serializationSpan = finishedSpans.get(1);
+      Assert.assertEquals("serialize", serializationSpan.operationName());
+      Assert.assertEquals(2, serializationSpan.tags().size());
+      Assert.assertNotNull(serializationSpan.tags().get("entity.type"));
+      Assert.assertEquals(MediaType.TEXT_PLAIN, serializationSpan.tags().get("media.type"));
+      Assert.assertEquals(0, serializationSpan.logEntries().size());
+
+      MockSpan rootSpan = finishedSpans.get(2);
+      Assert.assertEquals("/test/" + methodPath, rootSpan.operationName());
+      Assert.assertEquals(5, rootSpan.tags().size());
+      Assert.assertNotNull(rootSpan.tags().get("serverHost"));
+      Assert.assertEquals("server", rootSpan.tags().get("span.kind"));
+      Assert.assertEquals("/api/test/happyPath", rootSpan.tags().get("http.url"));
+      Assert.assertEquals(200, rootSpan.tags().get("http.status_code"));
+      Assert.assertEquals("POST", rootSpan.tags().get("http.method"));
+      Assert.assertEquals(0, rootSpan.logEntries().size());
+    }
+  }
+
+  @Test
+  public void testTracesWhenFailingSerializing() throws Exception
+  {
+    String methodPath = "failSerializing";
+    try(Response response = execPostCall(methodPath, 500))
+    {
+      Assert.assertNotNull(response.getHeaderString("traceid"));
+      Assert.assertNotNull(response.getHeaderString("spanid"));
+
+      // is a list of spans in the order they were close/finish
+      // deserialization, serialization (response), serialization (error msg), and root
+      List<MockSpan> finishedSpans = MOCK_TRACER.finishedSpans();
+      Assert.assertEquals(4, finishedSpans.size());
+
+      MockSpan deserializationSpan = finishedSpans.get(0);
+      Assert.assertEquals("deserialize", deserializationSpan.operationName());
+      Assert.assertEquals(2, deserializationSpan.tags().size());
+      Assert.assertNotNull(deserializationSpan.tags().get("entity.type"));
+      Assert.assertEquals(MediaType.TEXT_PLAIN, deserializationSpan.tags().get("media.type"));
+      Assert.assertEquals(0, deserializationSpan.logEntries().size());
+
+      MockSpan serializationSpan = finishedSpans.get(1);
+      Assert.assertEquals("serialize", serializationSpan.operationName());
+      Assert.assertEquals(3, serializationSpan.tags().size());
+      Assert.assertNotNull(serializationSpan.tags().get("entity.type"));
+      Assert.assertEquals(MediaType.TEXT_PLAIN, serializationSpan.tags().get("media.type"));
+      Assert.assertEquals(true, serializationSpan.tags().get(Tags.ERROR.getKey()));
+      Assert.assertEquals(1, serializationSpan.logEntries().size());
+      Map<String, ?> serializationSpanErrorLogFields = serializationSpan.logEntries().get(0).fields();
+      Assert.assertEquals("error", serializationSpanErrorLogFields.get(Fields.EVENT));
+      Assert.assertTrue(serializationSpanErrorLogFields.get(Fields.ERROR_OBJECT) instanceof Exception);
+
+      MockSpan serializationErrorSpan = finishedSpans.get(2);
+      Assert.assertEquals("serialize", serializationErrorSpan.operationName());
+      Assert.assertEquals(2, serializationErrorSpan.tags().size());
+      Assert.assertEquals("io.dropwizard.jersey.errors.ErrorMessage", serializationErrorSpan.tags().get("entity.type"));
+
+      MockSpan rootSpan = finishedSpans.get(3);
+      Assert.assertEquals("/test/" + methodPath, rootSpan.operationName());
+      Assert.assertEquals(6, rootSpan.tags().size());
+      Assert.assertNotNull(rootSpan.tags().get("serverHost"));
+      Assert.assertEquals("server", rootSpan.tags().get("span.kind"));
+      Assert.assertEquals("/api/test/" + methodPath, rootSpan.tags().get("http.url"));
+      Assert.assertEquals(500, rootSpan.tags().get("http.status_code"));
+      Assert.assertEquals("POST", rootSpan.tags().get("http.method"));
+      Assert.assertEquals(true, rootSpan.tags().get(Tags.ERROR.getKey()));
+      Assert.assertEquals(1, rootSpan.logEntries().size());
+      Map<String, ?> rootSpanErrorLogFields = rootSpan.logEntries().get(0).fields();
+      Assert.assertEquals("error", rootSpanErrorLogFields.get(Fields.EVENT));
+      Assert.assertEquals("Error on serialize", rootSpanErrorLogFields.get(Fields.MESSAGE));
+    }
+  }
+
+  @Test
+  public void testTracesWhenFailingDeserializing() throws Exception
+  {
+    String methodPath = "failDeserializing";
+    try(Response response = execPostCall(methodPath, 415))
+    {
+      Assert.assertNotNull(response.getHeaderString("traceid"));
+      Assert.assertNotNull(response.getHeaderString("spanid"));
+
+      // is a list of spans in the order they were close/finish
+      // deserialization, serialization (error msg), and root
+      List<MockSpan> finishedSpans = MOCK_TRACER.finishedSpans();
+      Assert.assertEquals(3, finishedSpans.size());
+
+      MockSpan deserializationSpan = finishedSpans.get(0);
+      Assert.assertEquals("deserialize", deserializationSpan.operationName());
+      Assert.assertEquals(3, deserializationSpan.tags().size());
+      Assert.assertNotNull(deserializationSpan.tags().get("entity.type"));
+      Assert.assertEquals(MediaType.TEXT_PLAIN, deserializationSpan.tags().get("media.type"));
+      Assert.assertEquals(true, deserializationSpan.tags().get(Tags.ERROR.getKey()));
+      Assert.assertEquals(1, deserializationSpan.logEntries().size());
+      Map<String, ?> deserializationSpanErrorLogFields = deserializationSpan.logEntries().get(0).fields();
+      Assert.assertEquals("error", deserializationSpanErrorLogFields.get(Fields.EVENT));
+      Assert.assertTrue(deserializationSpanErrorLogFields.get(Fields.ERROR_OBJECT) instanceof Exception);
+
+      MockSpan serializationErrorSpan = finishedSpans.get(1);
+      Assert.assertEquals("serialize", serializationErrorSpan.operationName());
+      Assert.assertEquals(2, serializationErrorSpan.tags().size());
+      Assert.assertEquals("io.dropwizard.jersey.errors.ErrorMessage", serializationErrorSpan.tags().get("entity.type"));
+
+      MockSpan rootSpan = finishedSpans.get(2);
+      Assert.assertEquals("/test/" + methodPath, rootSpan.operationName());
+      Assert.assertEquals(6, rootSpan.tags().size());
+      Assert.assertNotNull(rootSpan.tags().get("serverHost"));
+      Assert.assertEquals("server", rootSpan.tags().get("span.kind"));
+      Assert.assertEquals("/api/test/" + methodPath, rootSpan.tags().get("http.url"));
+      Assert.assertEquals(415, rootSpan.tags().get("http.status_code"));
+      Assert.assertEquals("POST", rootSpan.tags().get("http.method"));
+      Assert.assertEquals(true, rootSpan.tags().get(Tags.ERROR.getKey()));
+      Assert.assertEquals(1, rootSpan.logEntries().size());
+      Map<String, ?> rootSpanErrorLogFields = rootSpan.logEntries().get(0).fields();
+      Assert.assertEquals("error", rootSpanErrorLogFields.get(Fields.EVENT));
+      Assert.assertEquals("Error on deserialize", rootSpanErrorLogFields.get(Fields.MESSAGE));
+    }
+  }
+
+  private Response execPostCall(String methodPath, int status) throws Exception
+  {
+    Client client = RULE.client();
+    Response response =
+        client
+            .target(String.format("http://localhost:%d/api/test/%s", RULE.getLocalPort(), methodPath))
+            .request(MediaType.TEXT_PLAIN_TYPE)
+            .post(Entity.text("Hello World!"));
+
+    if (!methodPath.equals("skipped"))
+    {
+      // sync with server, only proceeding when root span is finished
+      REQ_BARR.await(2, TimeUnit.SECONDS);
+    }
+
+    assertEquals(status, response.getStatus());
+
+    return response;
+  }
+
+  public static class TestApp extends Application<TestConfig>
+  {
+    @Override
+    public void initialize(Bootstrap<TestConfig> bootstrap)
+    {
+      Assert.assertTrue("Other tracker already registered: " + GlobalTracer.get().toString(), GlobalTracer.registerIfAbsent(MOCK_TRACER));
+      super.initialize(bootstrap);
+      bootstrap.addBundle(new OpenTracingBundle(Collections.emptyList(), Collections.singletonList("/api/test/skipped")));
+    }
+
+    @Override
+    public void run(TestConfig testConfig, Environment environment)
+    {
+      environment.jersey().setUrlPattern("/api/*");
+      environment.jersey().register(new Resource());
+    }
+  }
+
+  public static class TestConfig extends Configuration
+  {
+  }
+
+  @Path("/test")
+  public static class Resource
+  {
+    @Path("/skipped")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String skipped(String payload)
+    {
+      return payload;
+    }
+
+    @Path("/happyPath")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String happyPath(String payload)
+    {
+      return payload;
+    }
+
+    @Path("/failSerializing")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response failSerializing(String payload)
+    {
+      StreamingOutput so = os ->
+      {
+        throw new RuntimeException();
+      };
+      return Response.ok().entity(so).build();
+    }
+
+    @Path("/failDeserializing")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    // there is no text_plain to map deserializer
+    public Map<String, String> failDeserializing(Map<String, String> payload)
+    {
+      return payload;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <nimbus.jwt.version>8.0</nimbus.jwt.version>
         <opentracing.jaxrs2.version>0.5.0</opentracing.jaxrs2.version>
         <opentracing.brave.version>0.37.2</opentracing.brave.version>
+        <opentracing.api.version>0.32.0</opentracing.api.version>
         <pac4j.version>3.8.3</pac4j.version>
         <prometheus.version>0.8.1</prometheus.version>
         <spring.test.version>4.3.24.RELEASE</spring.test.version>
@@ -518,6 +519,11 @@
                 <groupId>io.opentracing.brave</groupId>
                 <artifactId>brave-opentracing</artifactId>
                 <version>${opentracing.brave.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-mock</artifactId>
+                <version>${opentracing.api.version}</version>
             </dependency>
             <!-- Open Tracing -->
 


### PR DESCRIPTION
This PR enhances the open tracing jaxrs read and write interceptors so they log to the active span any exception found while reading request body or writing response entity.  

The main benefit of this change is to provide transparency during result streaming failures.  On those cases, we send a 200 status code, but while writing the entity, the server found some error.  The client only see the 200 and a corrupted HTTP response body, but have little transparency into why the corrupted entity.  By logging the error on the Span, clients and support teams can find the root cause querying the traces.

The PR include some classes forked from the [opentracing/java-jaxrs](https://github.com/opentracing-contrib/java-jaxrs).  This is to allow us to solve the problem we currently have while we work with the project maintainers on enhancing the trace interceptor. 