### PR TITLE
update Dockerfile to use standard openjdk image

### DIFF
--- a/legend-shared-server/Dockerfile
+++ b/legend-shared-server/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:11.0.12-bullseye
+FROM openjdk:11.0.12
 COPY target/legend-shared-server-*.jar /app/bin/
 CMD java -Xmx2G -Xms256M -Xss4M -cp /app/bin/*-shaded.jar -Dfile.encoding=UTF8 org.finos.legend.server.shared.staticserver.Server server /config/config.json


### PR DESCRIPTION
Use `openjdk:11.0.12` instead of `openjdk:11.0.12-bullseye` as `openjdk:11.0.12` already uses `bullseye`