### PR TITLE
publish CI test results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: legend-build
+name: Build CI
 
 env:
   CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
@@ -24,6 +24,7 @@ on: [push, pull_request]
   
 jobs:
   build:
+    name: Build
     if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
     runs-on: ubuntu-latest
     steps:
@@ -61,3 +62,15 @@ jobs:
     - name: Build + Test + Sonar + Maven Deploy
       if: (github.repository == 'finos/legend-shared') && (github.ref == 'refs/heads/master')
       run: mvn javadoc:javadoc deploy -Psonar -pl !legend-shared-test-reports
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: legend-shared-test-reports/surefire-reports-aggregate/*.xml
+    - name: Upload CI Event
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: event-file
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -1,0 +1,42 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build CI"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Publish Test Results
+    if: github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Debug Only
+        run: echo ${{ github.event.workflow_run.conclusion }}
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts && cd artifacts
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1.35
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: Test Results
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
-![legend-build](https://github.com/finos/legend-shared/workflows/legend-build/badge.svg)
+![Build CI](https://github.com/finos/legend-shared/workflows/Build%20CI/badge.svg)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=legend-shared&metric=security_rating&token=4c3f5479f7a32d754c947207987569fc14c7bba9)](https://sonarcloud.io/dashboard?id=legend-shared)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=legend-shared&metric=bugs&token=4c3f5479f7a32d754c947207987569fc14c7bba9)](https://sonarcloud.io/dashboard?id=legend-shared)
 

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,8 @@
                 <configuration>
                     <useSystemClassLoader>true</useSystemClassLoader>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <testFailureIgnore>true</testFailureIgnore>
+                    <trimStackTrace>false</trimStackTrace>
                     <reportsDirectory>${project.parent.basedir}/legend-shared-test-reports/surefire-reports-aggregate
                     </reportsDirectory>
                 </configuration>


### PR DESCRIPTION
publish CI test results so we can see failure as annotations and debug quicker

plugin doc: https://github.com/marketplace/actions/publish-unit-test-results
example: https://github.com/gomichutsk-stormborn/java-sample