### PR TITLE
allow specifying session cookie name

### DIFF
--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/Server.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/Server.java
@@ -20,6 +20,7 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.session.SessionHandler;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -106,5 +107,11 @@ public class Server extends Application<org.finos.legend.server.shared.staticser
     public void run(org.finos.legend.server.shared.staticserver.StaticServerConfiguration staticServerConfiguration,
                     Environment environment)
     {
+        SessionHandler sessionHandler = new SessionHandler();
+        if (staticServerConfiguration.getSessionCookie() != null)
+        {
+            sessionHandler.setSessionCookie(staticServerConfiguration.getSessionCookie());
+        }
+        environment.servlets().setSessionHandler(sessionHandler);
     }
 }

--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerConfiguration.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerConfiguration.java
@@ -24,7 +24,9 @@ import org.finos.legend.server.pac4j.LegendPac4jConfiguration;
 @SuppressWarnings({"unused", "FieldMayBeFinal"})
 public class StaticServerConfiguration extends Configuration
 {
-
+  // This can be set to avoid Jetty session cookie name collision between multiple servers running on `localhost` during development
+  // See https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid
+  private String sessionCookie;
   private String uiPath;
   private boolean html5Router;
 
@@ -35,6 +37,11 @@ public class StaticServerConfiguration extends Configuration
   public List<String> getRouterExemptPaths()
   {
     return routerExemptPaths;
+  }
+
+  public String getSessionCookie()
+  {
+    return sessionCookie;
   }
 
   public String getUiPath()


### PR DESCRIPTION
Allow specifying session cookie name to help with local development (when we have multiple Legend applications)

see https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid