### PR TITLE
upgrade commons-text to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-
         <!-- Dependencies -->
         <commons.lang.version>2.6</commons.lang.version>
+        <commons.text.version>1.10.0</commons.text.version>
         <dropwizard.version>1.3.29</dropwizard.version>
         <dropwizard.pac4j.version>3.0.0</dropwizard.pac4j.version>
         <guava.version>30.0-jre</guava.version>
@@ -601,6 +601,11 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons.lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons.text.version}</version>
             </dependency>
             <!-- Commons -->
 


### PR DESCRIPTION
See https://github.com/finos/legend-studio/actions/runs/3417676609/jobs/5689085409

```
┌──────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────┐
│                 Library                  │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                      Title                      │
├──────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────┤
│ org.apache.commons:commons-text          │ CVE-2022-42889 │ CRITICAL │ 1.9               │ 1.10.0        │ apache-commons-text: variable interpolation RCE │
│ (legend-shared-server-0.23.0-shaded.jar) │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-[42](https://github.com/finos/legend-studio/actions/runs/3417676609/jobs/5689085409#step:9:43)889      │
└──────────────────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────┘
```

https://nvd.nist.gov/vuln/detail/CVE-2022-42889

---

Solution: upgrade `commons-text@1.10.0`