### PR TITLE
upgrade commons-text to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
                 <version>${commons.lang.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
+                <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${commons.text.version}</version>
             </dependency>


### PR DESCRIPTION
See https://github.com/finos/legend-studio/actions/runs/3417676609/jobs/5689085409

```
┌──────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────┐
│                 Library                  │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                      Title                      │
├──────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────┤
│ org.apache.commons:commons-text          │ CVE-2022-42889 │ CRITICAL │ 1.9               │ 1.10.0        │ apache-commons-text: variable interpolation RCE │
│ (legend-shared-server-0.23.0-shaded.jar) │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-[42](https://github.com/finos/legend-studio/actions/runs/3417676609/jobs/5689085409#step:9:43)889      │
└──────────────────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────┘
```

https://nvd.nist.gov/vuln/detail/CVE-2022-42889

---

Solution: upgrade to `commons-text@1.10.0`
RE: I messed up in https://github.com/finos/legend-shared/pull/171 so this is the correction :)