### PR TITLE
Actions for handling release failures

### DIFF
--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.FINOS_GITHUB_TOKEN }}
 
       - name: Configure git

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -14,7 +14,8 @@
 
 
 # This action deletes the last two commits made on the master branch and the latest tag
-# This should only be run if a release failed and the remote staging repo has been dropped
+# This should only be run if a release failed and the remote staging repo has been dropped:
+# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
 name: Clean repo after failed release
 
 on: [workflow_dispatch]

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -1,0 +1,41 @@
+# Copyright 2022 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This action deletes the last two commits made on the master branch and the latest tag
+# This should only be run if a release failed and the remote staging repo has been dropped
+name: Clean repo after failed release
+
+on: [workflow_dispatch]
+
+jobs:
+  clean-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "37706051+finos-admin@users.noreply.github.com"
+          git config --global user.name "FINOS Administrator"
+
+      - name: Clean repo
+        run: |
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          git push --delete origin $LATEST_TAG
+          git reset --hard HEAD~2
+          git push --force

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Get staging repo Id
         run: |
           mvn nexus-staging:rc-list | tee rc-list.log
-          idLine=$(grep 'orgfinosshared' rc-list.log | grep '${{ github.event.inputs.releaseVersion }}')
+          idLine=$(grep 'orgfinoslegend' rc-list.log | grep '${{ github.event.inputs.releaseVersion }}')
           arrLine=(${idLine// / })
           repoId=${arrLine[1]}
           echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -1,0 +1,73 @@
+# Copyright 2022 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This action retries closing a staging repository in Nexus (Maven Central)
+# This should only be run if a release fails with the following message:
+# [ERROR] Remote staging finished with a failure: java.net.SocketException: Connection timed out (Read failed)
+name: Close and Release Staging Repository (In case of release failure)
+
+env:
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+  CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Version of the release that failed to close it's staging repo"
+        required: true
+
+jobs:
+  close-staging-repo:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "37706051+finos-admin@users.noreply.github.com"
+          git config --global user.name "FINOS Administrator"
+
+      - name: Set up Maven Central
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+          server-id: ossrh
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
+          gpg-passphrase: CI_GPG_PASSPHRASE
+
+      - name: Get staging repo Id
+        run: |
+          mvn nexus-staging:rc-list | tee rc-list.log
+          idLine=$(grep 'orgfinosshared' rc-list.log | grep '${{ github.event.inputs.releaseVersion }}')
+          arrLine=(${idLine// / })
+          repoId=${arrLine[1]}
+          echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV
+
+      - name: Close staging repo
+        run: mvn nexus-staging:rc-close -DstagingRepositoryId=${{ env.NEXUS_REPO_ID }}
+
+      - name: Release staging repo
+        run: mvn nexus-staging:rc-release -DstagingRepositoryId=${{ env.NEXUS_REPO_ID }}


### PR DESCRIPTION
The release action may fail in 2 different ways due to OSSRH:

1. The artifacts are uploaded to OSSRH, but the staging repo is not closed and released (in this case we trigger an action to simply close & release the stagin repo)
2. The staging process in OSSHR fails and the staging repo is dropped (in this case we delete the release tag and commits from the master branch and run a new release action)