### PR TITLE
pac4j: make callback base URL configurable

### DIFF
--- a/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jBundle.java
+++ b/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jBundle.java
@@ -124,7 +124,7 @@ public class LegendPac4jBundle<C extends Configuration> extends Pac4jBundle<C> i
       throw new RuntimeException(e);
     }
 
-    String applicationContextPath = "/";
+    String applicationContextPath = legendConfig.getCallbackBaseUrl() != null && !legendConfig.getCallbackBaseUrl().isEmpty() ? legendConfig.getCallbackBaseUrl() : "/";
     if (configuration.getServerFactory() instanceof SimpleServerFactory)
     {
       applicationContextPath = ((SimpleServerFactory) configuration.getServerFactory())

--- a/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jConfiguration.java
+++ b/legend-shared-pac4j/src/main/java/org/finos/legend/server/pac4j/LegendPac4jConfiguration.java
@@ -38,6 +38,7 @@ public final class LegendPac4jConfiguration
   private String mongoDb;
   private MongoSessionConfiguration mongoSession = new MongoSessionConfiguration();
   private String callbackPrefix = "";
+  private String callbackBaseUrl = "";
   private List<String> bypassPaths = ImmutableList.of();
   private List<String> bypassBranches = ImmutableList.of();
   private List<String> trustedPackages = ImmutableList.of();
@@ -209,6 +210,16 @@ public final class LegendPac4jConfiguration
     {
       this.callbackPrefix = callbackPrefix;
     }
+  }
+
+  public String getCallbackBaseUrl()
+  {
+    return callbackBaseUrl;
+  }
+
+  public void setCallbackBaseUrl(String callbackBaseUrl)
+  {
+    this.callbackBaseUrl = callbackBaseUrl;
   }
 
   public void loadDefaults(ConfigurationSourceProvider configurationSourceProvider,


### PR DESCRIPTION
When we deploy a Legend backend (e.g. SDLC) on a remote environment, for example, [Legend Omnibus](https://github.com/finos/legend/tree/master/installers/omnibus), since internally, the backend server might be started with a particular port, say `6100`, the `Pac4J` callback URL is always constructed as `http://localhost:6100/...`, but this is definitely not reachable if we deployed this on a remote server, so we need the ability configure the base URL for the callback URL here