### PR TITLE
Handle Static-Root with trailing /

### DIFF
--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
@@ -21,7 +21,6 @@ import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.finos.legend.server.pac4j.LegendPac4jBundle;

--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
@@ -76,7 +76,8 @@ public class StaticServerBundle<C extends Configuration> implements ConfiguredBu
       {
         skipPaths.addAll(staticConfig.getRouterExemptPaths());
       }
-      new HtmlRouterRedirectBundle(staticPath, skipPaths, Objects.equals(staticPath, "/") ? "/index.html" : staticPath + "/index.html")
+      String trimmedStaticPath = staticPath != null && staticPath.endsWith("/") ? staticPath.substring(0, staticPath.length() - 1) : staticPath;
+      new HtmlRouterRedirectBundle(staticPath, skipPaths, trimmedStaticPath + "/index.html")
           .run(environment);
     }
     environment.healthChecks().register("Static", new org.finos.legend.server.shared.staticserver.StaticHealthcheck());

--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
@@ -21,6 +21,7 @@ import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.finos.legend.server.pac4j.LegendPac4jBundle;
@@ -75,7 +76,7 @@ public class StaticServerBundle<C extends Configuration> implements ConfiguredBu
       {
         skipPaths.addAll(staticConfig.getRouterExemptPaths());
       }
-      new HtmlRouterRedirectBundle(staticPath, skipPaths, staticPath + "/index.html")
+      new HtmlRouterRedirectBundle(staticPath, skipPaths, Objects.equals(staticPath, "/") ? "/index.html" : staticPath + "/index.html")
           .run(environment);
     }
     environment.healthChecks().register("Static", new org.finos.legend.server.shared.staticserver.StaticHealthcheck());

--- a/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
+++ b/legend-shared-server/src/main/java/org/finos/legend/server/shared/staticserver/StaticServerBundle.java
@@ -77,7 +77,7 @@ public class StaticServerBundle<C extends Configuration> implements ConfiguredBu
         skipPaths.addAll(staticConfig.getRouterExemptPaths());
       }
       String trimmedStaticPath = staticPath != null && staticPath.endsWith("/") ? staticPath.substring(0, staticPath.length() - 1) : staticPath;
-      new HtmlRouterRedirectBundle(staticPath, skipPaths, trimmedStaticPath + "/index.html")
+      new HtmlRouterRedirectBundle(trimmedStaticPath, skipPaths, trimmedStaticPath + "/index.html")
           .run(environment);
     }
     environment.healthChecks().register("Static", new org.finos.legend.server.shared.staticserver.StaticHealthcheck());


### PR DESCRIPTION
In order to support serving static assets at the root path (/), we should remove trailing slashes from the static path config property so that a value of `/` will redirect to `/index.html` instead of `//index.html`.