### PR TITLE
Migrate to Maven CI-friendly versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
+    if: "github.repository == 'finos/legend-shared'"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-# This action deletes the last two commits made on the master branch and the latest tag
-# This should only be run if a release failed and the remote staging repo has been dropped:
-# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
+# This action deletes the latest tag after a failed release.
+# With CI-friendly versions, there are no release commits to clean up — only the tag.
 name: Clean repo after failed release
 
 on: [workflow_dispatch]
@@ -39,5 +38,3 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           git push --delete origin $LATEST_TAG
-          git reset --hard HEAD~2
-          git push --force

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -52,22 +52,29 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.client_payload.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals=clean release:prepare -DreleaseVersion=${{ github.event.client_payload.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and deploy release
+        run: |
+          mvn -B -e -Drevision=${{ github.event.client_payload.releaseVersion }} \
+            deploy -P release,docker
 
-      - name: Perform release
-        run: mvn -B release:perform -P release,docker
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.client_payload.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,42 +54,27 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals=clean release:prepare -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
-
-      - name: Checkout the latest tag
-        run: |
-          mkdir -p target/checkout
-          git clone --depth 1 --branch ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }} https://github.com/${{ github.repository }}.git target/checkout
-
-      - name: Build the latest tag
-        working-directory: target/checkout
-        run: mvn -B -e -T2 -DskipTests install -P release,docker
+      - name: Build release
+        run: mvn -B -e -T2 -DskipTests -Drevision=${{ github.event.inputs.releaseVersion }} install -P release,docker
         env:
           MAVEN_OPTS: -Xmx14g
 
-      - name: Test the latest tag
-        working-directory: target/checkout
-        run: mvn -B -e -T2 -DargLine="-Xmx6g" surefire:test -P release,docker
+      - name: Test release
+        run: mvn -B -e -T2 -DargLine="-Xmx6g" -Drevision=${{ github.event.inputs.releaseVersion }} surefire:test -P release,docker
         env:
           MAVEN_OPTS: -Xmx2g
 
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+
       - name: Create bundle to publish
-        working-directory: target/checkout
         run: |
           mkdir -p central-staging/org/finos/legend
           cp -R ~/.m2/repository/org/finos/legend/shared central-staging/org/finos/legend
@@ -100,12 +85,12 @@ jobs:
             sha256sum "$file" | awk '{print $1}' > "$file.sha256"
             sha512sum "$file" | awk '{print $1}' > "$file.sha512"
           done
-          
+
           mkdir central-publishing
           cd central-staging && zip -r ../central-publishing/central-bundle.zip org
 
       - name: Publish bundle
-        working-directory: target/checkout/central-publishing
+        working-directory: central-publishing
         run: |
           token=$(printf "$CI_DEPLOY_USERNAME:$CI_DEPLOY_PASSWORD" | base64)
           httpCode=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $token" --form bundle=@central-bundle.zip https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC)
@@ -140,3 +125,15 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.inputs.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/target
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
+**/.flattened-pom.xml
 .vscode
 .settings
 .project

--- a/legend-shared-opentracing-base/pom.xml
+++ b/legend-shared-opentracing-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.finos.legend.shared</groupId>
     <artifactId>legend-shared</artifactId>
-    <version>0.34.1-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>legend-shared-opentracing-base</artifactId>

--- a/legend-shared-opentracing-base/pom.xml
+++ b/legend-shared-opentracing-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.finos.legend.shared</groupId>
     <artifactId>legend-shared</artifactId>
-    <version>0.35.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>legend-shared-opentracing-base</artifactId>

--- a/legend-shared-opentracing-jersey/pom.xml
+++ b/legend-shared-opentracing-jersey/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>legend-shared</artifactId>
     <groupId>org.finos.legend.shared</groupId>
-    <version>0.34.1-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>legend-shared-opentracing-jersey</artifactId>

--- a/legend-shared-opentracing-jersey/pom.xml
+++ b/legend-shared-opentracing-jersey/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>legend-shared</artifactId>
     <groupId>org.finos.legend.shared</groupId>
-    <version>0.35.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>legend-shared-opentracing-jersey</artifactId>

--- a/legend-shared-opentracing-servlet-filter/pom.xml
+++ b/legend-shared-opentracing-servlet-filter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-opentracing-servlet-filter</artifactId>

--- a/legend-shared-opentracing-servlet-filter/pom.xml
+++ b/legend-shared-opentracing-servlet-filter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-opentracing-servlet-filter</artifactId>

--- a/legend-shared-opentracing-test/pom.xml
+++ b/legend-shared-opentracing-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-opentracing-test</artifactId>

--- a/legend-shared-opentracing-test/pom.xml
+++ b/legend-shared-opentracing-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-opentracing-test</artifactId>

--- a/legend-shared-pac4j-gitlab/pom.xml
+++ b/legend-shared-pac4j-gitlab/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-gitlab</artifactId>

--- a/legend-shared-pac4j-gitlab/pom.xml
+++ b/legend-shared-pac4j-gitlab/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-gitlab</artifactId>

--- a/legend-shared-pac4j-kerberos/pom.xml
+++ b/legend-shared-pac4j-kerberos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-kerberos</artifactId>

--- a/legend-shared-pac4j-kerberos/pom.xml
+++ b/legend-shared-pac4j-kerberos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-kerberos</artifactId>

--- a/legend-shared-pac4j-ping/pom.xml
+++ b/legend-shared-pac4j-ping/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-shared</artifactId>
         <groupId>org.finos.legend.shared</groupId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-ping</artifactId>

--- a/legend-shared-pac4j-ping/pom.xml
+++ b/legend-shared-pac4j-ping/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-shared</artifactId>
         <groupId>org.finos.legend.shared</groupId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j-ping</artifactId>

--- a/legend-shared-pac4j/pom.xml
+++ b/legend-shared-pac4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j</artifactId>

--- a/legend-shared-pac4j/pom.xml
+++ b/legend-shared-pac4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-pac4j</artifactId>

--- a/legend-shared-server/pom.xml
+++ b/legend-shared-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-server</artifactId>

--- a/legend-shared-server/pom.xml
+++ b/legend-shared-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-server</artifactId>

--- a/legend-shared-test-reports/pom.xml
+++ b/legend-shared-test-reports/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.34.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-test-reports</artifactId>

--- a/legend-shared-test-reports/pom.xml
+++ b/legend-shared-test-reports/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.shared</groupId>
         <artifactId>legend-shared</artifactId>
-        <version>0.35.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-shared-test-reports</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,13 @@
     <name>Legend Shared</name>
     <groupId>org.finos.legend.shared</groupId>
     <artifactId>legend-shared</artifactId>
-    <version>0.34.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
+        <!-- CI-Friendly Version -->
+        <revision>0.34.1-SNAPSHOT</revision>
+
         <sonar.projectKey>legend-shared</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 
@@ -209,6 +212,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,13 @@
     <name>Legend Shared</name>
     <groupId>org.finos.legend.shared</groupId>
     <artifactId>legend-shared</artifactId>
-    <version>0.35.4-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
+        <!-- CI-Friendly Version -->
+        <revision>0.35.4-SNAPSHOT</revision>
+
         <sonar.projectKey>legend-shared</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 
@@ -209,6 +212,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
Replace hardcoded version across all 11 POMs with ${revision}, add flatten-maven-plugin, and rewrite release workflows to use -Drevision= instead of maven-release-plugin. This eliminates the two-commit release dance, tag-checkout rebuild, and force-push recovery flow.