### PR TITLE
Bump the next SNAPSHOT on the branch tip, not the tested commit

### DIFF
--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -68,13 +68,15 @@ jobs:
           git push origin ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
 
       - name: Compute and set next SNAPSHOT
+        env:
+          RELEASE_VERSION: ${{ github.event.client_payload.releaseVersion }}
         run: |
-          releaseVersion=${{ github.event.client_payload.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          set -euo pipefail
+          IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
+          nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
           sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
           git add pom.xml
           git commit -m "Bump version to ${nextSnapshot}"
-          git push origin master
+          git push origin "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,15 @@ jobs:
           done
 
       - name: Compute and set next SNAPSHOT
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          set -euo pipefail
+          IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
+          nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
           sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
           git add pom.xml
           git commit -m "Bump version to ${nextSnapshot}"
-          git push origin master
+          git push origin "${GITHUB_REF_NAME}"


### PR DESCRIPTION
Small follow-up to #249.

The "Compute and set next SNAPSHOT" step in `release.yml` and `legend-stack-release.yml` committed the bump on the checked-out HEAD and ran `git push origin master`. If anything landed on master while the release ran, that push was rejected as non-fast-forward and the branch was left on the old SNAPSHOT.

Now the step fetches the branch tip, commits the one-line `<revision>` change on top of it, and pushes to the branch the workflow ran on (`GITHUB_REF_NAME`) rather than hard-coded `master`. The same step shape is used in the CI-friendly-version PRs for legend-depot, legend-sdlc, legend-pure and legend-engine.
