### PR TITLE
Fix the post-release version bump and stop rebuilding on tag pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,16 @@ env:
   CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-on: [push, pull_request]
-  
+on:
+  push:
+    # Branch pushes only. A release tag lands on a commit this workflow already
+    # built when it went onto the branch, so building it again on the tag push
+    # spends a second full build on it and hands `Publish Test Results` a
+    # duplicate set of results for the same commit.
+    tags-ignore:
+      - '**'
+  pull_request:
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -40,6 +40,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
+      - name: Verify nothing landed since this run was dispatched
+        run: |
+          set -euo pipefail
+          # The version bump at the end of this run commits onto the commit
+          # built here, so a branch that has moved turns that push into a
+          # non-fast-forward. Fail now, before anything is deployed or tagged,
+          # rather than after. This is not the only guard: that push is plain
+          # and never forced, so git still rejects it if the branch moves
+          # between this check and the bump.
+          tip="$(git ls-remote origin "refs/heads/${GITHUB_REF_NAME}" | cut -f1)"
+          if [ "${tip}" != "${GITHUB_SHA}" ]; then
+            echo "::error::${GITHUB_REF_NAME} moved from ${GITHUB_SHA} to ${tip} after this run was dispatched. Nothing has been deployed or tagged; dispatch the release again."
+            exit 1
+          fi
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -74,9 +89,18 @@ jobs:
           set -euo pipefail
           IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
           nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          git fetch origin "${GITHUB_REF_NAME}"
-          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
+          # Committed onto the commit that was built, deployed and tagged --
+          # HEAD, which is the "Legend Stack Versions upgrade" commit when one
+          # was made -- never onto whatever the remote tip has become, so the
+          # push below is a plain fast-forward: if anything landed on the branch
+          # after the check above, git rejects it rather than reverting a
+          # <revision> somebody else changed.
+          git checkout -B "${GITHUB_REF_NAME}" HEAD
           sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          if git diff --quiet -- pom.xml; then
+            echo "::error::sed left pom.xml unchanged; set <revision> to ${nextSnapshot} by hand on ${GITHUB_REF_NAME}."
+            exit 1
+          fi
           git add pom.xml
           git commit -m "Bump version to ${nextSnapshot}"
           git push origin "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
+      - name: Verify nothing landed since this run was dispatched
+        run: |
+          set -euo pipefail
+          # The version bump at the end of this run commits onto the commit
+          # built here, so a branch that has moved turns that push into a
+          # non-fast-forward. Fail now, before anything is deployed or tagged,
+          # rather than after. This is not the only guard: that push is plain
+          # and never forced, so git still rejects it if the branch moves
+          # between this check and the bump.
+          tip="$(git ls-remote origin "refs/heads/${GITHUB_REF_NAME}" | cut -f1)"
+          if [ "${tip}" != "${GITHUB_SHA}" ]; then
+            echo "::error::${GITHUB_REF_NAME} moved from ${GITHUB_SHA} to ${tip} after this run was dispatched. Nothing has been deployed or tagged; dispatch the release again."
+            exit 1
+          fi
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -133,9 +148,17 @@ jobs:
           set -euo pipefail
           IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
           nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          git fetch origin "${GITHUB_REF_NAME}"
-          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
+          # Committed onto the commit that was built, deployed and tagged,
+          # never onto whatever the remote tip has become, so the push below is
+          # a plain fast-forward: if anything landed on the branch after the
+          # check above, git rejects it rather than reverting a <revision>
+          # somebody else changed.
+          git checkout -B "${GITHUB_REF_NAME}" "${GITHUB_SHA}"
           sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          if git diff --quiet -- pom.xml; then
+            echo "::error::sed left pom.xml unchanged; set <revision> to ${nextSnapshot} by hand on ${GITHUB_REF_NAME}."
+            exit 1
+          fi
           git add pom.xml
           git commit -m "Bump version to ${nextSnapshot}"
           git push origin "${GITHUB_REF_NAME}"


### PR DESCRIPTION
Port of the release-workflow fixes Kevin Knight made in finos/legend-pure#1336 after the CI-friendly versions migration; the same problems exist here.

## Version bump on a moved branch

The "Compute and set next SNAPSHOT" step fetched the branch tip and ran a blind `sed` on it, so a `<revision>` somebody changed deliberately during the release (a minor bump, say) was silently overwritten. Now:

- a step before the build fails if the branch has moved since the run was dispatched, so most races fail before anything is deployed or tagged;
- the bump is committed onto the commit that was built and tagged, so its push is a plain fast-forward that git rejects on a race instead of reverting someone else's change;
- the step fails if `sed` changed nothing.

In `legend-stack-release.yml` the check runs before the "Legend Stack Versions upgrade" commit and the bump sits on HEAD, which is that upgrade commit when one was made.

## Duplicate CI build on tag push

The release tag now lands on an ordinary commit that `build.yml` already built, so every release triggered a second full build on the tag push. `build.yml` now ignores tag pushes.

## Not needed here

`clean deploy` and dropping `-T` from the deploy (finos/legend-pure#1334) do not apply: this repo runs a single `mvn deploy` in a fresh checkout, without `-T`.

Not exercised locally beyond YAML linting; the bump logic is the same text as legend-pure's, which released 5.99.1 with it.

This supersedes #264, which introduced the tip-fetching bump here.
